### PR TITLE
Auto set DOMAIN env vars

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,10 @@
 tasks:
   - init: docker-compose pull --include-deps appwrite telegraf influxdb traefik
     command: |
+      DOMAIN=$(echo $GITPOD_WORKSPACE_URL | sed 's/https:\/\/appwrite/8080-appwrite/g')
+      sed -i "s/_APP_DOMAIN=localhost/_APP_DOMAIN=$DOMAIN/g" .env
+      sed -i "s/_APP_DOMAIN_FUNCTIONS=localhost/_APP_DOMAIN_FUNCTIONS=$DOMAIN/g" .env
+      sed -i "s/_APP_DOMAIN_TARGET=localhost/_APP_DOMAIN_TARGET=$DOMAIN/g" .env
       docker-compose up
 
 ports:


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

As of 1.4, it's required to set the DOMAIN env vars or else you'll get an error when trying to browse to the Appwrite Console. This uses the GITPOD_WORKSPACE_URL env var to set the DOMAIN env vars.

## Test Plan

I tested by spinning up gitpod and I was able to reach the Appwrite console since the .env was automatically updated.

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes