### PR TITLE
Updating Image Versions to 1.5.3 && Docker Compose to v2

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,7 +5,7 @@ tasks:
       sed -i "s/_APP_DOMAIN=localhost/_APP_DOMAIN=$DOMAIN/g" .env
       sed -i "s/_APP_DOMAIN_FUNCTIONS=localhost/_APP_DOMAIN_FUNCTIONS=$DOMAIN/g" .env
       sed -i "s/_APP_DOMAIN_TARGET=localhost/_APP_DOMAIN_TARGET=$DOMAIN/g" .env
-      docker-compose up
+      docker compose up
 
 ports:
   - port: 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ version: '3'
 
 services:
   traefik:
-    image: traefik:2.9
+    image: traefik:2.11
     container_name: appwrite-traefik
     <<: *x-logging
     command:
@@ -34,7 +34,7 @@ services:
       - appwrite
 
   appwrite:
-    image: appwrite/appwrite:1.4.13
+    image: appwrite/appwrite:1.5.3
     container_name: appwrite
     <<: *x-logging
     restart: unless-stopped
@@ -162,7 +162,7 @@ services:
       - _APP_ASSISTANT_OPENAI_API_KEY
 
   appwrite-realtime:
-    image: appwrite/appwrite:1.4.13
+    image: appwrite/appwrite:1.5.3
     entrypoint: realtime
     container_name: appwrite-realtime
     <<: *x-logging
@@ -206,7 +206,7 @@ services:
       - _APP_LOGGING_CONFIG
 
   appwrite-worker-audits:
-    image: appwrite/appwrite:1.4.13
+    image: appwrite/appwrite:1.5.3
     entrypoint: worker-audits
     <<: *x-logging
     container_name: appwrite-worker-audits
@@ -233,7 +233,7 @@ services:
       - _APP_LOGGING_CONFIG
 
   appwrite-worker-webhooks:
-    image: appwrite/appwrite:1.4.13
+    image: appwrite/appwrite:1.5.3
     entrypoint: worker-webhooks
     <<: *x-logging
     container_name: appwrite-worker-webhooks
@@ -256,7 +256,7 @@ services:
       - _APP_LOGGING_CONFIG
 
   appwrite-worker-deletes:
-    image: appwrite/appwrite:1.4.13
+    image: appwrite/appwrite:1.5.3
     entrypoint: worker-deletes
     <<: *x-logging
     container_name: appwrite-worker-deletes
@@ -312,7 +312,7 @@ services:
       - _APP_EXECUTOR_HOST
 
   appwrite-worker-databases:
-    image: appwrite/appwrite:1.4.13
+    image: appwrite/appwrite:1.5.3
     entrypoint: worker-databases
     <<: *x-logging
     container_name: appwrite-worker-databases
@@ -339,7 +339,7 @@ services:
       - _APP_LOGGING_CONFIG
 
   appwrite-worker-builds:
-    image: appwrite/appwrite:1.4.13
+    image: appwrite/appwrite:1.5.3
     entrypoint: worker-builds
     <<: *x-logging
     container_name: appwrite-worker-builds
@@ -403,7 +403,7 @@ services:
       - _APP_STORAGE_WASABI_BUCKET
 
   appwrite-worker-certificates:
-    image: appwrite/appwrite:1.4.13
+    image: appwrite/appwrite:1.5.3
     entrypoint: worker-certificates
     <<: *x-logging
     container_name: appwrite-worker-certificates
@@ -437,7 +437,7 @@ services:
       - _APP_LOGGING_CONFIG
 
   appwrite-worker-functions:
-    image: appwrite/appwrite:1.4.13
+    image: appwrite/appwrite:1.5.3
     entrypoint: worker-functions
     <<: *x-logging
     container_name: appwrite-worker-functions
@@ -474,7 +474,7 @@ services:
       - _APP_LOGGING_PROVIDER
 
   appwrite-worker-mails:
-    image: appwrite/appwrite:1.4.13
+    image: appwrite/appwrite:1.5.3
     entrypoint: worker-mails
     <<: *x-logging
     container_name: appwrite-worker-mails
@@ -502,7 +502,7 @@ services:
       - _APP_LOGGING_CONFIG
 
   appwrite-worker-messaging:
-    image: appwrite/appwrite:1.4.13
+    image: appwrite/appwrite:1.5.3
     entrypoint: worker-messaging
     <<: *x-logging
     container_name: appwrite-worker-messaging
@@ -524,7 +524,7 @@ services:
       - _APP_LOGGING_CONFIG
 
   appwrite-worker-migrations:
-    image: appwrite/appwrite:1.4.13
+    image: appwrite/appwrite:1.5.3
     entrypoint: worker-migrations
     <<: *x-logging
     container_name: appwrite-worker-migrations
@@ -555,7 +555,7 @@ services:
       - _APP_MIGRATIONS_FIREBASE_CLIENT_SECRET
 
   appwrite-maintenance:
-    image: appwrite/appwrite:1.4.13
+    image: appwrite/appwrite:1.5.3
     entrypoint: maintenance
     <<: *x-logging
     container_name: appwrite-maintenance
@@ -589,7 +589,7 @@ services:
       - _APP_MAINTENANCE_RETENTION_SCHEDULES
 
   appwrite-usage:
-    image: appwrite/appwrite:1.4.13
+    image: appwrite/appwrite:1.5.3
     entrypoint: usage
     container_name: appwrite-usage
     <<: *x-logging
@@ -620,7 +620,7 @@ services:
       - _APP_LOGGING_CONFIG
 
   appwrite-schedule:
-    image: appwrite/appwrite:1.4.13
+    image: appwrite/appwrite:1.5.3
     entrypoint: schedule
     container_name: appwrite-schedule
     <<: *x-logging
@@ -645,7 +645,7 @@ services:
       - _APP_DB_PASS
 
   appwrite-assistant:
-    image: appwrite/assistant:0.2.2
+    image: appwrite/assistant:0.4.0
     container_name: appwrite-assistant
     <<: *x-logging
     restart: unless-stopped
@@ -660,7 +660,7 @@ services:
     <<: *x-logging
     restart: unless-stopped
     stop_signal: SIGINT
-    image: openruntimes/executor:0.4.5
+    image: openruntimes/executor:0.4.9
     networks:
       - appwrite
       - runtimes
@@ -705,7 +705,7 @@ services:
       - OPR_EXECUTOR_STORAGE_WASABI_BUCKET=$_APP_STORAGE_WASABI_BUCKET
 
   mariadb:
-    image: mariadb:10.7 # fix issues when upgrading using: mysql_upgrade -u root -p
+    image: mariadb:10.11 # fix issues when upgrading using: mysql_upgrade -u root -p
     container_name: appwrite-mariadb
     <<: *x-logging
     restart: unless-stopped
@@ -721,7 +721,7 @@ services:
     command: 'mysqld --innodb-flush-method=fsync'
 
   redis:
-    image: redis:7.0.4-alpine
+    image: redis:7.2.4-alpine
     container_name: appwrite-redis
     <<: *x-logging
     restart: unless-stopped


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Updates Images to 1.5.3 and `docker compose up` to V2 from V1. 

## Test Plan

Forked repo, generated link: https://gitpod.io/#https://github.com/EVDOG4LIFE/integration-for-gitpod and created workspace. Successfully. 

See screenshot for verification:

![image](https://github.com/appwrite/integration-for-gitpod/assets/23223867/045dd8de-fabb-47a6-8a52-0a709b475ece)

## Related PRs and Issues

https://github.com/appwrite/integration-for-gitpod/issues/14 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes